### PR TITLE
Updating README virtual patent marking URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,4 +76,4 @@ Patent Notice
 -------------
 
 This software is covered by one or more patents. For a full list, please visit:
-`https://www.appliedbrainresearch.com/leading-ai-chip-innovators-explore-our-patents-at-abr`
+`https://www.appliedbrainresearch.com/patents


### PR DESCRIPTION
Fixed the URL for this on appliedbrainresearch.com, updating here now.